### PR TITLE
Clear Raven's context after sending an event.

### DIFF
--- a/lib/qless/middleware/sentry.rb
+++ b/lib/qless/middleware/sentry.rb
@@ -11,6 +11,7 @@ module Qless
         super
       rescue Exception => e
         SentryLogger.new(e, job).log
+        ::Raven::Context.clear!
         raise
       end
 


### PR DESCRIPTION
Without this any calls to `Raven.extra_context(...)` can leak between jobs.